### PR TITLE
Add GitHub Pages deployment setup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     
     permissions:
-      contents: read
+      contents: write
       pages: write
       id-token: write
 
@@ -39,6 +39,17 @@ jobs:
       env:
         NODE_ENV: production
 
+    # Deploy to gh-pages branch
+    - name: Deploy to gh-pages branch
+      if: github.ref == 'refs/heads/main'
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./dist
+        publish_branch: gh-pages
+        force_orphan: true
+
+    # Standard GitHub Pages deployment
     - name: Setup Pages
       if: github.ref == 'refs/heads/main'
       uses: actions/configure-pages@v4

--- a/README.md
+++ b/README.md
@@ -239,3 +239,38 @@ While this is a personal portfolio, suggestions for improvements are welcome:
 ---
 
 **Built with ❤️ by Naukhaiz Aftab** | **© 2025 All Rights Reserved**
+
+## 🚀 GitHub Pages Deployment
+
+This repository is configured for **dual deployment** to GitHub Pages:
+
+### Method 1: Standard GitHub Pages (Recommended)
+The repository deploys automatically to GitHub Pages using GitHub Actions.
+
+**Setup:**
+1. Go to **Settings** → **Pages**
+2. Set **Source** to "GitHub Actions"
+3. The workflow will automatically deploy on push to `main`
+4. Site will be available at: `https://naukhaiz-aftab.github.io/`
+
+### Method 2: gh-pages Branch
+Additionally, the workflow creates a `gh-pages` branch with built files.
+
+**Setup:**
+1. Go to **Settings** → **Pages** 
+2. Set **Source** to "Deploy from a branch"
+3. Select **branch**: `gh-pages`
+4. Select **folder**: `/ (root)`
+5. Click **Save**
+6. Site will be available at: `https://naukhaiz-aftab.github.io/`
+
+### Manual gh-pages Deployment
+If you need to manually deploy:
+
+```bash
+# Build the project
+npm run build
+
+# Deploy to gh-pages branch
+npm run deploy:gh-pages
+```

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --ext ts,tsx --fix",
     "type-check": "tsc --noEmit",
-    "deploy": "npm run build && gh-pages -d dist"
+    "deploy": "npm run build && gh-pages -d dist",
+    "deploy:gh-pages": "npm run build && gh-pages -d dist -b gh-pages"
   },
   "dependencies": {
     "gsap": "^3.12.2"


### PR DESCRIPTION
This PR adds comprehensive GitHub Pages deployment support to the legal portfolio repository. **Key Features:** 1. **Dual Deployment Options** - Standard GitHub Pages via GitHub Actions - Automatic gh-pages branch creation 2. **Enhanced GitHub Actions Workflow** - Builds and deploys automatically on push to main - Creates clean gh-pages branch with only built files - Maintains existing Lighthouse CI testing 3. **Manual Deployment Support** - Added npm run deploy:gh-pages script - Clear documentation in README 4. **Deployment Instructions** - Complete setup guide in README - Support for both deployment methods **After merging this PR:** 1. Go to Settings → Pages 2. Choose either GitHub Actions or gh-pages branch 3. Site will deploy automatically at https://naukhaiz-aftab.github.io/ This provides flexible deployment options and ensures the portfolio is easily accessible via GitHub Pages.