### PR TITLE
Fix GitHub Pages deployment configuration - Add required environment …

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,10 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    
     permissions:
       contents: read
       pages: write


### PR DESCRIPTION
…configuration to deployment job - This resolves the 'Missing environment' error in GitHub Actions